### PR TITLE
Improve mobile UI/make design adaptive

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-eslint": "~4.5.0",
     "@vue/cli-plugin-typescript": "~4.5.0",
+    "@vue/cli-plugin-vuex": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
     "@vue/compiler-sfc": "^3.0.0",
     "@vue/eslint-config-prettier": "^6.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -299,5 +299,9 @@ img {
   #app {
     width: 100%;
   }
+
+  html {
+    font-size: 10px;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -285,7 +285,6 @@ html,
 body,
 #app {
   height: 100%;
-  overflow: hidden;
 }
 
 img {

--- a/src/App.vue
+++ b/src/App.vue
@@ -304,4 +304,10 @@ img {
     font-size: 10px;
   }
 }
+
+@media screen and (max-height: 700px) and (orientation: landscape) {
+  html {
+    font-size: 10px;
+  }
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -254,14 +254,6 @@ export default defineComponent({
   src: local("Genshin"), url(./assets/fonts/Genshin.ttf) format("truetype");
 }
 
-@media screen and (orientation: portrait) {
-  #app {
-    transform: rotate(90deg);
-    width: 100vh;
-    height: 100vw;
-  }
-}
-
 #app {
   -webkit-font-smoothing: antialiased;
   text-align: center;
@@ -269,7 +261,6 @@ export default defineComponent({
   background: url("./assets/images/wish-background.png") center/cover no-repeat
       fixed,
     #8ac2eb;
-  min-height: max-content;
 }
 
 /* reset css */
@@ -285,10 +276,28 @@ html,
 body,
 #app {
   height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 img {
   /* to not have white flash on initial load */
   background-color: transparent;
+}
+
+@media screen and (orientation: portrait) {
+  body {
+    height: 100vw;
+    width: 100vh;
+    transform: rotate(90deg);
+    transform-origin: bottom left;
+    position: absolute;
+    top: -100vw;
+    left: 0;
+  }
+  #app {
+    width: 100%;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -254,6 +254,14 @@ export default defineComponent({
   src: local("Genshin"), url(./assets/fonts/Genshin.ttf) format("truetype");
 }
 
+@media screen and (orientation: portrait) {
+  #app {
+    transform: rotate(90deg);
+    width: 100vh;
+    height: 100vw;
+  }
+}
+
 #app {
   -webkit-font-smoothing: antialiased;
   text-align: center;

--- a/src/components/CancelConfirmButton.vue
+++ b/src/components/CancelConfirmButton.vue
@@ -161,6 +161,6 @@ export default defineComponent({
 .icon_delete {
   color: red;
   margin-top: 0.3rem;
-  width: 90%;
+  width: 80%;
 }
 </style>

--- a/src/components/CancelConfirmButton.vue
+++ b/src/components/CancelConfirmButton.vue
@@ -163,4 +163,12 @@ export default defineComponent({
   margin-top: 0.3rem;
   width: 80%;
 }
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  .cancel-confirm-button {
+    font-size: 1.5rem;
+    width: calc(var(--length) * 0.9);
+  }
+}
 </style>

--- a/src/components/FatePurchaseDialog.vue
+++ b/src/components/FatePurchaseDialog.vue
@@ -128,4 +128,11 @@ export default defineComponent({
 .fate-coloured {
   color: #f49c00;
 }
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  #dialog-fate-purchase {
+    font-size: 1.5rem;
+  }
+}
 </style>

--- a/src/components/PlusButton.vue
+++ b/src/components/PlusButton.vue
@@ -16,7 +16,7 @@ export default defineComponent({});
   height: 1.75rem;
   border-radius: 50%;
   background-color: #ece5d8;
-  font-size: 22pt;
+  font-size: 2rem;
   text-align: center;
   transition: 0.1s;
   outline: none;

--- a/src/components/QuestScreen.vue
+++ b/src/components/QuestScreen.vue
@@ -555,8 +555,7 @@ textarea.quest-description {
   background-color: #505863;
 }
 
-@media screen and (max-width: 850px) and (orientation: portrait),
-  (orientation: landscape) and (max-height: 850px) {
+@media screen and (max-width: 850px) and (orientation: portrait) {
   .header {
     padding-right: 3rem;
     margin-left: 0;

--- a/src/components/QuestScreen.vue
+++ b/src/components/QuestScreen.vue
@@ -467,7 +467,7 @@ textarea.quest-description {
   display: flex;
   justify-content: space-between;
   flex-direction: row;
-  height: 100%;
+  height: 85%;
   width: 85%;
 }
 

--- a/src/components/QuestScreen.vue
+++ b/src/components/QuestScreen.vue
@@ -554,4 +554,14 @@ textarea.quest-description {
 .gray {
   background-color: #505863;
 }
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  .header {
+    padding-right: 3rem;
+    margin-left: 0;
+    box-sizing: border-box;
+    padding-bottom: 0.5rem;
+  }
+}
 </style>

--- a/src/components/QuestScreen.vue
+++ b/src/components/QuestScreen.vue
@@ -277,8 +277,8 @@ export default defineComponent({
   position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -468,7 +468,7 @@ textarea.quest-description {
   justify-content: space-between;
   flex-direction: row;
   height: 100%;
-  width: 85vw;
+  width: 85%;
 }
 
 .quest-selector {

--- a/src/components/ShopScreen.vue
+++ b/src/components/ShopScreen.vue
@@ -144,6 +144,8 @@ export default defineComponent({
   align-items: center;
   width: 100%;
   margin-right: 3rem;
+  padding-right: 5rem;
+  box-sizing: border-box;
 }
 
 .shop-body {
@@ -221,8 +223,8 @@ export default defineComponent({
   position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/TextButton.vue
+++ b/src/components/TextButton.vue
@@ -72,7 +72,7 @@ export default defineComponent({
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),
-  (orientation: landscape) and (max-height: 850px) {
+  screen and (max-height: 700px) and (orientation: landscape) {
   .menu-button {
     transform: scale(75%);
     margin: 0;

--- a/src/components/TextButton.vue
+++ b/src/components/TextButton.vue
@@ -37,7 +37,7 @@ export default defineComponent({
   border: solid transparent;
   box-shadow: 0 2px 2px 0 rgba(100, 100, 100, 0.2),
     0 2px 2px 0 rgba(100, 100, 100, 0.19);
-  font-size: 14pt;
+  font-size: 1.25rem;
   color: black;
   text-align: center;
   transition: border 0.3s;

--- a/src/components/TextButton.vue
+++ b/src/components/TextButton.vue
@@ -70,4 +70,12 @@ export default defineComponent({
       #e0ddd4;
   }
 }
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  .menu-button {
+    transform: scale(75%);
+    margin: 0;
+  }
+}
 </style>

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -64,8 +64,8 @@ export default defineComponent({
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
 

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -332,10 +332,9 @@ export default defineComponent({
 }
 
 .mobile-header {
-  min-width: 4%;
-  max-width: 6%;
+  width: 5%;
   height: 100%;
-  background: linear-gradient(to bottom, #424b5c, #7a8d9c);
+  background: linear-gradient(to bottom, #424b5c, #7a8d9c88);
   display: flex;
   flex-direction: column;
   margin-left: 2rem;
@@ -345,6 +344,8 @@ export default defineComponent({
   padding-bottom: 1rem;
   align-items: center;
   transform: translateX(1rem);
+  border-left: 0.1rem solid #978b72;
+  border-right: 0.1rem solid #978b72;
 }
 
 .mobile-header > .header-resizable {
@@ -552,7 +553,7 @@ export default defineComponent({
   color: #f6f2ee;
   text-shadow: 1px 1px rgba(2, 2, 2, 0.3);
   user-select: none;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),
@@ -569,6 +570,7 @@ export default defineComponent({
 
   #wish-buttons {
     transform: translateY(-1.75rem);
+    width: 55%;
   }
 
   #shop-buttons {
@@ -580,9 +582,12 @@ export default defineComponent({
   }
 
   #header {
-    margin-top: 0;
     width: 100%;
-    margin-left: 0;
+    margin: 0;
+  }
+
+  p#wish-label {
+    margin-right: 10rem;
   }
 
   .banner {

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -370,6 +370,7 @@ export default defineComponent({
 
 .header-resizable {
   min-width: 2rem;
+  max-width: calc(100% / 3);
 }
 
 .invisible {
@@ -557,6 +558,8 @@ export default defineComponent({
   text-shadow: 1px 1px rgba(2, 2, 2, 0.3);
   user-select: none;
   font-size: 1.25rem;
+  margin-left: 0;
+  padding-right: 0.5rem;
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -44,11 +44,13 @@
           <img
             :src="getBannerHeaderImage(ban, true)"
             v-if="currentBannerIndex === index"
+            class="header-resizable"
           />
           <img
             :src="getBannerHeaderImage(ban)"
             v-else
             @click="changeBanner(index)"
+            class="header-resizable"
           />
         </template>
       </div>
@@ -90,35 +92,31 @@
         stateExiting ? 'exit-animation' : 'start-animation',
       ]"
     >
-      <div>
-        <div id="masterless-home" class="footer-align-flex left-align-flex">
-          <gem-counter
-            icon="starglitter.png"
-            :text="inventory.starglitter"
-            @image-clicked="activeItemId = 'starglitter'"
-            nobackground
-          ></gem-counter>
-          <gem-counter
-            icon="stardust.png"
-            :text="inventory.stardust"
-            @image-clicked="activeItemId = 'stardust'"
-            nobackground
-          ></gem-counter>
-        </div>
-        <div id="shop-buttons" class="footer-align-flex">
-          <text-button
-            text="Shop"
-            @clicked="targetExitEmit = 'go-shop'"
-          ></text-button>
-          <text-button
-            text="Details"
-            @clicked="showDetails = true"
-          ></text-button>
-          <text-button
-            text="History"
-            @clicked="showHistory = true"
-          ></text-button>
-        </div>
+      <div
+        v-if="!isMobile"
+        id="masterless-home"
+        class="footer-align-flex left-align-flex"
+      >
+        <gem-counter
+          icon="starglitter.png"
+          :text="inventory.starglitter"
+          @image-clicked="activeItemId = 'starglitter'"
+          nobackground
+        ></gem-counter>
+        <gem-counter
+          icon="stardust.png"
+          :text="inventory.stardust"
+          @image-clicked="activeItemId = 'stardust'"
+          nobackground
+        ></gem-counter>
+      </div>
+      <div id="shop-buttons" class="footer-align-flex">
+        <text-button
+          text="Shop"
+          @clicked="targetExitEmit = 'go-shop'"
+        ></text-button>
+        <text-button text="Details" @clicked="showDetails = true"></text-button>
+        <text-button text="History" @clicked="showHistory = true"></text-button>
       </div>
       <div id="wish-buttons" class="footer-align-flex">
         <wish-button
@@ -189,13 +187,14 @@ export default defineComponent({
       showHistory: false,
       activeItemId: "",
       targetExitEmit: "" as "wish" | "go-quests" | "go-shop" | "",
+      windowHeight: window.innerHeight,
+      windowWidth: window.innerWidth,
     };
   },
   computed: {
     banner(): Banner {
       return this.banners[this.currentBannerIndex];
     },
-
     getBannerImage(): string {
       const images = require.context(
         "../assets/images/banners/",
@@ -213,6 +212,9 @@ export default defineComponent({
     },
     stateExiting(): boolean {
       return this.targetExitEmit !== "";
+    },
+    isMobile(): boolean {
+      return this.windowHeight > this.windowWidth && this.windowWidth < 850;
     },
   },
   methods: {
@@ -261,6 +263,18 @@ export default defineComponent({
     exit(): void {
       this.$emit("go-quests");
     },
+    onResize() {
+      this.windowHeight = window.innerHeight;
+      this.windowWidth = window.innerWidth;
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      window.addEventListener("resize", () => this.onResize);
+    });
+  },
+  beforeUnmount() {
+    window.removeEventListener("resize", this.onResize);
   },
   emits: ["wish", "go-quests", "go-shop", "change-banner"],
 });
@@ -284,6 +298,11 @@ export default defineComponent({
   gap: 2vw;
 }
 
+.header-resizable {
+  min-width: 2rem;
+  max-width: calc(100% / 3);
+}
+
 .invisible {
   /* TODO: display: none also triggers the entry animation so:
    * use v-if for simplicity or make it an actual overlay using position: fixed
@@ -303,6 +322,7 @@ export default defineComponent({
 #header {
   animation: fadein 0.75s forwards, slide-from-top 0.75s forwards ease-out;
   margin-bottom: 0;
+  min-height: 20%;
 }
 
 #header.exit-animation {
@@ -327,7 +347,8 @@ export default defineComponent({
   display: flex;
   align-items: center;
   justify-content: center;
-  max-height: 70%;
+  max-height: 60%;
+  max-width: 100%;
 }
 
 #div-banner.start-animation {
@@ -342,10 +363,11 @@ export default defineComponent({
 #banner {
   max-width: 90%;
   max-height: 100%;
+  height: 100%;
 }
 
 #footer {
-  min-height: 4rem;
+  min-height: 20%;
 }
 
 #footer.start-animation {
@@ -432,7 +454,7 @@ export default defineComponent({
 .footer-align-flex {
   display: flex;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
 }
 
@@ -442,7 +464,7 @@ export default defineComponent({
 
 #wish-label > img {
   width: 3rem;
-  margin-right: 3rem;
+  margin-right: 20%;
 }
 
 .space-between {
@@ -461,15 +483,31 @@ export default defineComponent({
   margin-bottom: auto;
 }
 
-.wish-container + .wish-container {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
 #wish-label {
   color: #f6f2ee;
   text-shadow: 1px 1px rgba(2, 2, 2, 0.3);
   user-select: none;
   font-size: 16pt;
+}
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  .menu-button {
+    transform: scale(75%);
+    margin: 0;
+  }
+
+  .footer-align-flex {
+    flex-wrap: nowrap;
+    align-items: flex-start;
+  }
+
+  #wish-buttons {
+    transform: translateY(-1.75rem);
+  }
+
+  #shop-buttons {
+    width: 45%;
+  }
 }
 </style>

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -251,7 +251,10 @@ export default defineComponent({
       return this.targetExitEmit !== "";
     },
     isMobile(): boolean {
-      return this.windowHeight > this.windowWidth && this.windowWidth < 850;
+      return (
+        (this.windowHeight > this.windowWidth && this.windowWidth < 850) ||
+        this.windowHeight < 700
+      );
     },
   },
   methods: {
@@ -557,7 +560,7 @@ export default defineComponent({
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),
-  (orientation: landscape) and (max-height: 850px) {
+  screen and (max-height: 700px) and (orientation: landscape) {
   .menu-button {
     transform: scale(75%);
     margin: 0;

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -39,7 +39,7 @@
         <img src="../assets/images/ui-wish-edited.png" />
         <p id="wish-label">Wish</p>
       </div>
-      <div class="banner-header">
+      <div class="banner-header" v-if="!isMobile">
         <template v-for="(ban, index) of banners" :key="index">
           <img
             :src="getBannerHeaderImage(ban, true)"
@@ -55,6 +55,18 @@
         </template>
       </div>
       <div id="gems">
+        <gem-counter
+          icon="starglitter.png"
+          :text="inventory.starglitter"
+          @image-clicked="activeItemId = 'starglitter'"
+          v-if="isMobile"
+        ></gem-counter>
+        <gem-counter
+          icon="stardust.png"
+          :text="inventory.stardust"
+          @image-clicked="activeItemId = 'stardust'"
+          v-if="isMobile"
+        ></gem-counter>
         <gem-counter
           icon="primogem.png"
           :text="inventory.primos"
@@ -92,31 +104,39 @@
         stateExiting ? 'exit-animation' : 'start-animation',
       ]"
     >
-      <div
-        v-if="!isMobile"
-        id="masterless-home"
-        class="footer-align-flex left-align-flex"
-      >
-        <gem-counter
-          icon="starglitter.png"
-          :text="inventory.starglitter"
-          @image-clicked="activeItemId = 'starglitter'"
-          nobackground
-        ></gem-counter>
-        <gem-counter
-          icon="stardust.png"
-          :text="inventory.stardust"
-          @image-clicked="activeItemId = 'stardust'"
-          nobackground
-        ></gem-counter>
-      </div>
-      <div id="shop-buttons" class="footer-align-flex">
-        <text-button
-          text="Shop"
-          @clicked="targetExitEmit = 'go-shop'"
-        ></text-button>
-        <text-button text="Details" @clicked="showDetails = true"></text-button>
-        <text-button text="History" @clicked="showHistory = true"></text-button>
+      <div id="shop-button-holder-sometimes">
+        <div
+          v-if="!isMobile"
+          id="masterless-home"
+          class="footer-align-flex left-align-flex"
+        >
+          <gem-counter
+            icon="starglitter.png"
+            :text="inventory.starglitter"
+            @image-clicked="activeItemId = 'starglitter'"
+            nobackground
+          ></gem-counter>
+          <gem-counter
+            icon="stardust.png"
+            :text="inventory.stardust"
+            @image-clicked="activeItemId = 'stardust'"
+            nobackground
+          ></gem-counter>
+        </div>
+        <div id="shop-buttons" class="footer-align-flex">
+          <text-button
+            text="Shop"
+            @clicked="targetExitEmit = 'go-shop'"
+          ></text-button>
+          <text-button
+            text="Details"
+            @clicked="showDetails = true"
+          ></text-button>
+          <text-button
+            text="History"
+            @clicked="showHistory = true"
+          ></text-button>
+        </div>
       </div>
       <div id="wish-buttons" class="footer-align-flex">
         <wish-button
@@ -268,10 +288,8 @@ export default defineComponent({
       this.windowWidth = window.innerWidth;
     },
   },
-  mounted() {
-    this.$nextTick(() => {
-      window.addEventListener("resize", () => this.onResize);
-    });
+  created() {
+    this.$nextTick(() => window.addEventListener("resize", this.onResize));
   },
   beforeUnmount() {
     window.removeEventListener("resize", this.onResize);
@@ -507,6 +525,10 @@ export default defineComponent({
   }
 
   #shop-buttons {
+    width: 100%;
+  }
+
+  #shop-button-holder-sometimes {
     width: 45%;
   }
 }

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -388,7 +388,7 @@ export default defineComponent({
 #header {
   animation: fadein 0.75s forwards, slide-from-top 0.75s forwards ease-out;
   margin-bottom: 0;
-  min-height: 20%;
+  max-height: min-content;
 }
 
 #header.exit-animation {
@@ -433,7 +433,7 @@ export default defineComponent({
 }
 
 #footer {
-  min-height: 20%;
+  max-height: min-content;
 }
 
 #footer.start-animation {
@@ -592,6 +592,10 @@ export default defineComponent({
 
   .banner {
     width: 90%;
+  }
+
+  #div-banner {
+    max-height: 80%;
   }
 }
 </style>

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -597,5 +597,10 @@ export default defineComponent({
   #div-banner {
     max-height: 80%;
   }
+
+  #header {
+    padding-right: 5rem;
+    box-sizing: border-box;
+  }
 }
 </style>

--- a/src/components/WishBanners.vue
+++ b/src/components/WishBanners.vue
@@ -19,146 +19,163 @@
   <audio id="audio-banner-switch" preload="true">
     <source src="@/assets/audio/banner-switch.mp3" />
   </audio>
-
-  <div
-    :class="{
-      banner: true,
-      invisible: showDetails || showHistory,
-    }"
-  >
-    <div
-      id="header"
-      :class="[
-        'space-between',
-        'center',
-        stateExiting ? 'exit-animation' : 'start-animation',
-      ]"
-      @animationend="exitEmit"
-    >
-      <div id="wish-label" class="space-between center">
-        <img src="../assets/images/ui-wish-edited.png" />
-        <p id="wish-label">Wish</p>
-      </div>
-      <div class="banner-header" v-if="!isMobile">
-        <template v-for="(ban, index) of banners" :key="index">
-          <img
-            :src="getBannerHeaderImage(ban, true)"
-            v-if="currentBannerIndex === index"
-            class="header-resizable"
-          />
-          <img
-            :src="getBannerHeaderImage(ban)"
-            v-else
-            @click="changeBanner(index)"
-            class="header-resizable"
-          />
-        </template>
-      </div>
-      <div id="gems">
-        <gem-counter
-          icon="starglitter.png"
-          :text="inventory.starglitter"
-          @image-clicked="activeItemId = 'starglitter'"
-          v-if="isMobile"
-        ></gem-counter>
-        <gem-counter
-          icon="stardust.png"
-          :text="inventory.stardust"
-          @image-clicked="activeItemId = 'stardust'"
-          v-if="isMobile"
-        ></gem-counter>
-        <gem-counter
-          icon="primogem.png"
-          :text="inventory.primos"
-          @image-clicked="activeItemId = 'primogem'"
-          plusSign
-        ></gem-counter>
-        <gem-counter
-          icon="acquaint-fate.png"
-          :text="inventory.standardFates"
-          @image-clicked="activeItemId = 'acquaint-fate'"
-          v-if="banner.storage === 'standard'"
-        ></gem-counter>
-        <gem-counter
-          icon="intertwined-fate.png"
-          :text="inventory.fates"
-          @image-clicked="activeItemId = 'intertwined-fate'"
+  <div class="banner-container">
+    <div class="mobile-header" v-if="isMobile">
+      <img src="../assets/images/ui-wish-edited.png" />
+      <template v-for="(ban, index) of banners" :key="index">
+        <img
+          :src="getBannerHeaderImage(ban, true)"
+          v-if="currentBannerIndex === index"
+          class="header-resizable"
+        />
+        <img
+          :src="getBannerHeaderImage(ban)"
           v-else
-        ></gem-counter>
-        <div class="close-box">
-          <close-button @clicked="exit"></close-button>
+          @click="changeBanner(index)"
+          class="header-resizable"
+        />
+      </template>
+    </div>
+    <div
+      :class="{
+        banner: true,
+        invisible: showDetails || showHistory,
+      }"
+    >
+      <div
+        id="header"
+        :class="[
+          'space-between',
+          'center',
+          stateExiting ? 'exit-animation' : 'start-animation',
+        ]"
+        @animationend="exitEmit"
+      >
+        <div id="wish-label" class="space-between center">
+          <img v-if="!isMobile" src="../assets/images/ui-wish-edited.png" />
+          <p id="wish-label">Wish</p>
         </div>
-      </div>
-    </div>
-    <div
-      id="div-banner"
-      :class="stateExiting ? 'exit-animation' : 'start-animation'"
-      :key="currentBannerIndex"
-    >
-      <img id="banner" :src="getBannerImage" />
-    </div>
-    <div
-      id="footer"
-      :class="[
-        'space-between',
-        stateExiting ? 'exit-animation' : 'start-animation',
-      ]"
-    >
-      <div id="shop-button-holder-sometimes">
-        <div
-          v-if="!isMobile"
-          id="masterless-home"
-          class="footer-align-flex left-align-flex"
-        >
+        <div class="banner-header" v-if="!isMobile">
+          <template v-for="(ban, index) of banners" :key="index">
+            <img
+              :src="getBannerHeaderImage(ban, true)"
+              v-if="currentBannerIndex === index"
+              class="header-resizable"
+            />
+            <img
+              :src="getBannerHeaderImage(ban)"
+              v-else
+              @click="changeBanner(index)"
+              class="header-resizable"
+            />
+          </template>
+        </div>
+        <div id="gems">
           <gem-counter
             icon="starglitter.png"
             :text="inventory.starglitter"
             @image-clicked="activeItemId = 'starglitter'"
-            nobackground
+            v-if="isMobile"
           ></gem-counter>
           <gem-counter
             icon="stardust.png"
             :text="inventory.stardust"
             @image-clicked="activeItemId = 'stardust'"
-            nobackground
+            v-if="isMobile"
           ></gem-counter>
-        </div>
-        <div id="shop-buttons" class="footer-align-flex">
-          <text-button
-            text="Shop"
-            @clicked="targetExitEmit = 'go-shop'"
-          ></text-button>
-          <text-button
-            text="Details"
-            @clicked="showDetails = true"
-          ></text-button>
-          <text-button
-            text="History"
-            @clicked="showHistory = true"
-          ></text-button>
+          <gem-counter
+            icon="primogem.png"
+            :text="inventory.primos"
+            @image-clicked="activeItemId = 'primogem'"
+            plusSign
+          ></gem-counter>
+          <gem-counter
+            icon="acquaint-fate.png"
+            :text="inventory.standardFates"
+            @image-clicked="activeItemId = 'acquaint-fate'"
+            v-if="banner.storage === 'standard'"
+          ></gem-counter>
+          <gem-counter
+            icon="intertwined-fate.png"
+            :text="inventory.fates"
+            @image-clicked="activeItemId = 'intertwined-fate'"
+            v-else
+          ></gem-counter>
+          <div class="close-box">
+            <close-button @clicked="exit"></close-button>
+          </div>
         </div>
       </div>
-      <div id="wish-buttons" class="footer-align-flex">
-        <wish-button
-          :wishes="1"
-          :fates="
-            banner.storage === 'standard'
-              ? inventory.standardFates
-              : inventory.fates
-          "
-          :standard="banner.storage === 'standard'"
-          @try-wish="wish(1)"
-        ></wish-button>
-        <wish-button
-          :wishes="10"
-          :fates="
-            banner.storage === 'standard'
-              ? inventory.standardFates
-              : inventory.fates
-          "
-          :standard="banner.storage === 'standard'"
-          @try-wish="wish(10)"
-        ></wish-button>
+      <div
+        id="div-banner"
+        :class="stateExiting ? 'exit-animation' : 'start-animation'"
+        :key="currentBannerIndex"
+      >
+        <img id="banner" :src="getBannerImage" />
+      </div>
+      <div
+        id="footer"
+        :class="[
+          'space-between',
+          stateExiting ? 'exit-animation' : 'start-animation',
+        ]"
+      >
+        <div id="shop-button-holder-sometimes">
+          <div
+            v-if="!isMobile"
+            id="masterless-home"
+            class="footer-align-flex left-align-flex"
+          >
+            <gem-counter
+              icon="starglitter.png"
+              :text="inventory.starglitter"
+              @image-clicked="activeItemId = 'starglitter'"
+              nobackground
+            ></gem-counter>
+            <gem-counter
+              icon="stardust.png"
+              :text="inventory.stardust"
+              @image-clicked="activeItemId = 'stardust'"
+              nobackground
+            ></gem-counter>
+          </div>
+          <div id="shop-buttons" class="footer-align-flex">
+            <text-button
+              text="Shop"
+              @clicked="targetExitEmit = 'go-shop'"
+            ></text-button>
+            <text-button
+              text="Details"
+              @clicked="showDetails = true"
+            ></text-button>
+            <text-button
+              text="History"
+              @clicked="showHistory = true"
+            ></text-button>
+          </div>
+        </div>
+        <div id="wish-buttons" class="footer-align-flex">
+          <wish-button
+            :wishes="1"
+            :fates="
+              banner.storage === 'standard'
+                ? inventory.standardFates
+                : inventory.fates
+            "
+            :standard="banner.storage === 'standard'"
+            @try-wish="wish(1)"
+          ></wish-button>
+          <wish-button
+            :wishes="10"
+            :fates="
+              banner.storage === 'standard'
+                ? inventory.standardFates
+                : inventory.fates
+            "
+            :standard="banner.storage === 'standard'"
+            @try-wish="wish(10)"
+          ></wish-button>
+        </div>
       </div>
     </div>
   </div>
@@ -303,22 +320,52 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  -webkit-font-smoothing: antialiased;
   text-align: center;
   color: #2c3e50;
   height: 100%;
+  width: 100%;
+}
+
+.banner-container {
+  height: 100%;
+  display: flex;
+}
+
+.mobile-header {
+  min-width: 4%;
+  max-width: 6%;
+  height: 100%;
+  background: linear-gradient(to bottom, #424b5c, #7a8d9c);
+  display: flex;
+  flex-direction: column;
+  margin-left: 2rem;
+  box-sizing: border-box;
+  gap: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  align-items: center;
+  transform: translateX(1rem);
+}
+
+.mobile-header > .header-resizable {
+  max-width: 8.5rem;
+}
+
+.mobile-header > img:not(.header-resizable) {
+  width: 80%;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
 }
 
 .banner-header {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 2vw;
+  gap: 1rem;
 }
 
 .header-resizable {
   min-width: 2rem;
-  max-width: calc(100% / 3);
 }
 
 .invisible {
@@ -505,7 +552,7 @@ export default defineComponent({
   color: #f6f2ee;
   text-shadow: 1px 1px rgba(2, 2, 2, 0.3);
   user-select: none;
-  font-size: 16pt;
+  font-size: 1.5rem;
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),
@@ -530,6 +577,16 @@ export default defineComponent({
 
   #shop-button-holder-sometimes {
     width: 45%;
+  }
+
+  #header {
+    margin-top: 0;
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .banner {
+    width: 90%;
   }
 }
 </style>

--- a/src/components/WishButton.vue
+++ b/src/components/WishButton.vue
@@ -92,7 +92,7 @@ p {
 }
 
 @media screen and (max-width: 850px) and (orientation: portrait),
-  (orientation: landscape) and (max-height: 850px) {
+  screen and (max-height: 700px) and (orientation: landscape) {
   p {
     font-size: 1rem;
   }

--- a/src/components/WishButton.vue
+++ b/src/components/WishButton.vue
@@ -90,4 +90,18 @@ p {
 .red {
   color: red;
 }
+
+@media screen and (max-width: 850px) and (orientation: portrait),
+  (orientation: landscape) and (max-height: 850px) {
+  p {
+    font-size: 1rem;
+  }
+  .fate-image {
+    width: 1.75rem;
+  }
+
+  .wish-button {
+    width: 15rem;
+  }
+}
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,11 @@
   resolved "https://registry.yarnpkg.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.13.tgz#98646d8bc1e69cf6c6a6cba2fed3eace0356c360"
   integrity sha512-I1S9wZC7iI0Wn8kw8Zh+A2Qkf6s1M6vTGBkx8boXjuzfwEEyEHRxadsVCecZc8Mkpydo0nykj+MyYF96TKFuVA==
 
+"@vue/cli-plugin-vuex@~4.5.0":
+  version "4.5.15"
+  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.15.tgz#466c1f02777d02fef53a9bb49a36cc3a3bcfec4e"
+  integrity sha512-fqap+4HN+w+InDxlA3hZTOGE0tzBTgXhKLoDydhywqgmhQ1D9JA6Feh94ze6tG8DsWX58/ujYUqA8jAz17FJtg==
+
 "@vue/cli-service@~4.5.0":
   version "4.5.13"
   resolved "https://registry.yarnpkg.com/@vue/cli-service/-/cli-service-4.5.13.tgz#a09e684a801684b6e24e5414ad30650970eec9ed"
@@ -10075,11 +10080,6 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-vue-class-component@^8.0.0-0:
-  version "8.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-8.0.0-rc.1.tgz#db692cd97656eb9a08206c03d0b7398cdb1d9420"
-  integrity sha512-w1nMzsT/UdbDAXKqhwTmSoyuJzUXKrxLE77PCFVuC6syr8acdFDAq116xgvZh9UCuV0h+rlCtxXolr3Hi3HyPQ==
 
 vue-cli-plugin-electron-builder@~2.1.1:
   version "2.1.1"


### PR DESCRIPTION
At this time, primoprod is not usable in portrait in part because of elements overflowing everywhere and wonky sizing and portrait orientation. This hinders users on mobile devices and in the upcoming Android app.

This PR aims to resolve all of those by revisiting the CSS of every element and adjusting them to fit the base game.

Resolves #4, #20.