### PR TITLE
settings: Save to local storage

### DIFF
--- a/src/components/ScreenSettings/SettingsScreen.vue
+++ b/src/components/ScreenSettings/SettingsScreen.vue
@@ -97,8 +97,6 @@ export default defineComponent({
         showBannerPity: this.settings.showBannerPity,
         everythingBanner: this.settings.everythingBanner,
       };
-      console.log(this.settings);
-      console.log(settings);
       this.$store.commit("updateSettings", settings);
       this.$emit("exit");
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,8 @@ switch (localStorage.version) {
           return pull;
         })
       );
+      console.log("Updated from pre-1.0.1 to 1.0.1");
     }
-    console.log("Updated from pre-1.0.1 to 1.0.1");
 }
 localStorage.version = 1;
 // end version upgrade

--- a/src/state/Gacha.ts
+++ b/src/state/Gacha.ts
@@ -62,7 +62,6 @@ export default class Gacha {
       JSON.parse(
         localStorage.getItem(this.storage) || JSON.stringify(this.state)
       );
-    console.log(this.state);
 
     this.settings = settings;
   }

--- a/src/state/Inventory.ts
+++ b/src/state/Inventory.ts
@@ -1,5 +1,4 @@
 import { Item, ItemStringQuantity, Pull } from "@/types";
-import Paimon from "./PaimonMoe";
 
 export default class Inventory {
   currency = {
@@ -22,7 +21,6 @@ export default class Inventory {
       localStorage.getItem("pullHistory") || JSON.stringify(this.pullHistory)
     );
     this.migrationCheck();
-    console.log(Paimon.export());
   }
 
   migrationCheck(): void {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,19 +6,24 @@ const store: Store<State> = createStore({
   state() {
     return {
       inventory: new Inventory(),
-      settings: {
-        infinitePrimos: false,
-        rollOnly: null,
-        winGuarantee: null,
-        unlimitedHistoryScroll: false,
-        showBannerPity: false,
-        everythingBanner: false,
-      },
+      settings: JSON.parse(
+        localStorage.settings ??
+          JSON.stringify({
+            // i'm sorry there has to be a nicer way to do this
+            infinitePrimos: false,
+            rollOnly: null,
+            winGuarantee: null,
+            unlimitedHistoryScroll: false,
+            showBannerPity: false,
+            everythingBanner: false,
+          })
+      ),
     };
   },
   mutations: {
     updateSettings(state, newSettings) {
       state.settings = newSettings;
+      localStorage.settings = JSON.stringify(state.settings);
     },
   },
 });


### PR DESCRIPTION
 - Console update message for old versions now only runs if an actual update was performed
 - Removed `console.log`s meant for debug
 - Save and load settings from local storage on change