### PR TITLE
Add dynamic banner creator

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
   </audio>
 
   <!-- overlay -->
+  <banner-splash />
   <fate-purchase-dialog
     v-if="
       pullNumber > (useStandardFates ? inv.standardFates : inv.fates) &&
@@ -86,6 +87,7 @@ import Gacha from "@/state/Gacha";
 import { Banner, Item, ItemStringQuantity } from "@/types";
 import Inventory from "@/state/Inventory";
 import GameMenu from "@/components/game/GameMenu.vue";
+import BannerSplash from "@/components/shared/BannerSplash.vue";
 
 // empty comment below is to maintain multi-line array
 // to keep prettier happy (do not remove)
@@ -110,6 +112,7 @@ export default defineComponent({
     QuestScreen,
     ShopScreen,
     GameMenu,
+    BannerSplash,
   },
   data() {
     return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,9 +9,9 @@
 
   <!-- overlay -->
   <banner-splash
-    :centerItemId="'yae-miko'"
-    :sideItemIds="[]"
-    :accentColor="'blah'"
+    :center-item-id="'yae-miko'"
+    :side-item-ids="[]"
+    :accent-color="'blah'"
   />
   <fate-purchase-dialog
     v-if="

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,11 @@
   </audio>
 
   <!-- overlay -->
-  <banner-splash />
+  <banner-splash
+    :centerItemId="'yae-miko'"
+    :sideItemIds="[]"
+    :accentColor="'blah'"
+  />
   <fate-purchase-dialog
     v-if="
       pullNumber > (useStandardFates ? inv.standardFates : inv.fates) &&

--- a/src/components/shared/BannerSplash.vue
+++ b/src/components/shared/BannerSplash.vue
@@ -1,0 +1,11 @@
+<template>
+  <div></div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({});
+</script>
+
+<style scoped></style>

--- a/src/components/shared/BannerSplash.vue
+++ b/src/components/shared/BannerSplash.vue
@@ -1,5 +1,30 @@
 <template>
-  <div></div>
+  <div class="box">
+    <div class="detail-box">
+      <div class="banner-text">Character Event Wish</div>
+      <h1 class="title-text">Everbloom Violet</h1>
+      <div class="description-box">
+        <h3>Probability increased!</h3>
+        <div class="wish-guarantee-box">
+          <p>
+            Every 10 wishes is guaranteed to include at least one 4-star or
+            higher item.
+          </p>
+        </div>
+        <p class="fluff-box">
+          5-star event-exclusive characters can only be obtained in the
+          specified wish during the specified time period(s). View Details for
+          more.
+        </p>
+      </div>
+      <div class="time-box">
+        <p>
+          Time Remaining <br />
+          20 day(s) 18 hour(s) 49 minute(s)
+        </p>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -8,4 +33,119 @@ import { defineComponent } from "vue";
 export default defineComponent({});
 </script>
 
-<style scoped></style>
+<style scoped>
+* {
+  --accent-color: #7f64d1;
+  --accent-color-trans: #7f64d1bb;
+  --bg-color: #f3f1ef;
+  --bg-color-bottom: #e8e0da;
+}
+
+.wish-guarantee-box {
+  background-color: var(--accent-color-trans);
+  padding: 0.25em;
+  padding-left: 1.5em;
+  color: white;
+  font-size: 1.4em;
+  line-height: 1.2em;
+  letter-spacing: -0.02em;
+}
+
+.description-box {
+  border: 1px dashed lightgray;
+  border-left: none;
+  border-right: none;
+  margin-top: 1em;
+  line-height: 1.1em;
+}
+
+.detail-box p,
+.detail-box h3 {
+  text-shadow: -0.05em -0.05em 0 var(--bg-color),
+    0.05em -0.05em 0 var(--bg-color), -0.05em 0.05em 0 var(--bg-color),
+    0.05em 0.05em 0 var(--bg-color);
+}
+
+.detail-box h3 {
+  color: #4a4846;
+  font-size: 1.8em;
+  letter-spacing: -0.045em;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.wish-guarantee-box p {
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+  text-shadow: none;
+}
+
+.fluff-box {
+  margin-top: 1em;
+  font-size: 1.45em;
+  line-height: 1.3em;
+  letter-spacing: -0.03em;
+  padding-bottom: 0.25em;
+}
+
+.time-box {
+  font-size: 1.45em;
+  line-height: 1.7em;
+  padding-top: 0.5em;
+}
+
+.banner-text {
+  position: relative;
+  left: -2.5em;
+  top: -0.3em;
+  width: 70%;
+  height: 1.7em;
+  background-color: var(--accent-color);
+  border-radius: 1em;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 1.75em;
+  display: grid;
+  place-items: center;
+  color: white;
+  font-weight: 500;
+  font-size: 1.4em;
+}
+
+.detail-box {
+  height: 100%;
+  width: 33%;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  background: linear-gradient(to right, var(--bg-color), transparent);
+}
+
+.title-text {
+  font-size: 3.5em;
+  line-height: 1.3em;
+  letter-spacing: -0.03em;
+  color: #4a4846;
+  text-shadow: -0.03em -0.03em 0 var(--bg-color),
+    0.03em -0.03em 0 var(--bg-color), -0.03em 0.03em 0 var(--bg-color),
+    0.03em 0.03em 0 var(--bg-color);
+  margin: 0;
+  margin-top: -0.5rem;
+}
+
+.detail-box {
+  padding-left: 3em;
+}
+
+.box {
+  margin: 1rem;
+  height: 42rem;
+  aspect-ratio: 680 / 350;
+  border-radius: 0.5em;
+  display: flex;
+  background: url("../../assets/images/drops/yae-miko.webp") no-repeat,
+    linear-gradient(to bottom, var(--bg-color), var(--bg-color-bottom));
+  background-size: 175%;
+  background-position: left calc(50% + 10%) top calc(50% + -17%);
+}
+</style>

--- a/src/components/shared/BannerSplash.vue
+++ b/src/components/shared/BannerSplash.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="box">
+  <div class="box" :style="centerImageStyle">
     <div class="detail-box">
       <div class="banner-text">Character Event Wish</div>
       <h1 class="title-text">Everbloom Violet</h1>
@@ -24,16 +24,57 @@
         </p>
       </div>
     </div>
+    <div class="image-holder">
+      <img src="@/assets/images/drops/diona.webp" />
+      <img src="@/assets/images/drops/fischl.webp" />
+      <img src="@/assets/images/drops/thoma.webp" />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { Item } from "@/types";
+import { ItemDatabase } from "@/state/Gacha";
 
-export default defineComponent({});
+export default defineComponent({
+  props: {
+    centerItemId: {
+      type: String,
+      required: true,
+    },
+    sideItemIds: {
+      type: Object as () => string[],
+      required: true,
+    },
+    accentColor: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    centerImageStyle(): { [key: string]: string } {
+      return {
+        "--center-img-src": `url(../../assets/images/drops/${this.centerItem.id}.webp)`,
+      };
+    },
+    centerItem(): Item {
+      return ItemDatabase[this.centerItemId];
+    },
+    sideItems(): Item[] {
+      return this.sideItemIds.map((i) => ItemDatabase[i]);
+    },
+  },
+});
 </script>
 
 <style scoped>
+.image-holder img {
+  width: 40rem;
+}
 * {
   --accent-color: #7f64d1;
   --accent-color-trans: #7f64d1bb;
@@ -143,7 +184,7 @@ export default defineComponent({});
   aspect-ratio: 680 / 350;
   border-radius: 0.5em;
   display: flex;
-  background: url("../../assets/images/drops/yae-miko.webp") no-repeat,
+  background: --center-img-src no-repeat,
     linear-gradient(to bottom, var(--bg-color), var(--bg-color-bottom));
   background-size: 175%;
   background-position: left calc(50% + 10%) top calc(50% + -17%);

--- a/src/components/shared/BannerSplash.vue
+++ b/src/components/shared/BannerSplash.vue
@@ -1,3 +1,20 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { ItemDatabase } from "@/state/Gacha";
+
+const props = defineProps<{
+  centerItemId: string;
+  sideItemIds: string[];
+  accentColor: string;
+}>();
+
+const centerItem = computed(() => ItemDatabase[props.centerItemId]);
+const centerImageStyle = computed(
+  () => `url(../../assets/images/drops/${centerItem.value.id}.webp)`
+);
+const sideItems = computed(() => props.sideItemIds.map((i) => ItemDatabase[i]));
+</script>
+
 <template>
   <div class="box" :style="centerImageStyle">
     <div class="detail-box">
@@ -31,45 +48,6 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import { Item } from "@/types";
-import { ItemDatabase } from "@/state/Gacha";
-
-export default defineComponent({
-  props: {
-    centerItemId: {
-      type: String,
-      required: true,
-    },
-    sideItemIds: {
-      type: Object as () => string[],
-      required: true,
-    },
-    accentColor: {
-      type: String,
-      required: true,
-    },
-  },
-  data() {
-    return {};
-  },
-  computed: {
-    centerImageStyle(): { [key: string]: string } {
-      return {
-        "--center-img-src": `url(../../assets/images/drops/${this.centerItem.id}.webp)`,
-      };
-    },
-    centerItem(): Item {
-      return ItemDatabase[this.centerItemId];
-    },
-    sideItems(): Item[] {
-      return this.sideItemIds.map((i) => ItemDatabase[i]);
-    },
-  },
-});
-</script>
 
 <style scoped>
 .image-holder img {
@@ -184,7 +162,7 @@ export default defineComponent({
   aspect-ratio: 680 / 350;
   border-radius: 0.5em;
   display: flex;
-  background: --center-img-src no-repeat,
+  background: v-bind(centerImageStyle) no-repeat,
     linear-gradient(to bottom, var(--bg-color), var(--bg-color-bottom));
   background-size: 175%;
   background-position: left calc(50% + 10%) top calc(50% + -17%);


### PR DESCRIPTION
At the cost of exactly matching design, add a low-network custom banner generator that is defined by the banner JSON. This removes the need of requiring banner and banner header images for each banner, instead letting the user programmatically combine existing assets to design them.

If the banner `custom` field is not defined, fall back to serving images. Otherwise, follow the `custom` spec.